### PR TITLE
Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,29 @@
 name := "sangria-spray-json"
 organization := "org.sangria-graphql"
-version := "1.0.2-SNAPSHOT"
+version := "1.0.3-SNAPSHOT"
 
 description := "Sangria spray-json marshalling"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.11", "2.12.4")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.11.11", "2.12.8", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 scalacOptions ++= {
-  if (scalaVersion.value startsWith "2.12")
-    Seq.empty
-  else
+  if (scalaVersion.value startsWith "2.11")
     Seq("-target:jvm-1.7")
+  else
+    Seq.empty
 }
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.0",
-  "io.spray" %%  "spray-json" % "1.3.4",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "2.0.0-SNAPSHOT",
+  "io.spray" %%  "spray-json" % "1.3.5",
 
-  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.1" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.1.0-SNAPSHOT" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 )
 
 // Publishing

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.2.8

--- a/src/main/scala/sangria/marshalling/sprayJson.scala
+++ b/src/main/scala/sangria/marshalling/sprayJson.scala
@@ -18,20 +18,20 @@ object sprayJson extends SprayJsonSupportLowPrioImplicits {
 
     def arrayNode(values: Vector[JsValue]) = JsArray(values.toVector)
     def optionalArrayNodeValue(value: Option[JsValue]) = value match {
-      case Some(v) ⇒ v
-      case None ⇒ nullNode
+      case Some(v) => v
+      case None => nullNode
     }
 
     def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]) = value match {
-      case v: String ⇒ JsString(v)
-      case v: Boolean ⇒ JsBoolean(v)
-      case v: Int ⇒ JsNumber(v)
-      case v: Long ⇒ JsNumber(v)
-      case v: Float ⇒ JsNumber(v)
-      case v: Double ⇒ JsNumber(v)
-      case v: BigInt ⇒ JsNumber(v)
-      case v: BigDecimal ⇒ JsNumber(v)
-      case v ⇒ throw new IllegalArgumentException("Unsupported scalar value: " + v)
+      case v: String => JsString(v)
+      case v: Boolean => JsBoolean(v)
+      case v: Int => JsNumber(v)
+      case v: Long => JsNumber(v)
+      case v: Float => JsNumber(v)
+      case v: Double => JsNumber(v)
+      case v: BigInt => JsNumber(v)
+      case v: BigDecimal => JsNumber(v)
+      case v => throw new IllegalArgumentException("Unsupported scalar value: " + v)
     }
 
     def enumNode(value: String, typeName: String) = JsString(value)
@@ -58,10 +58,10 @@ object sprayJson extends SprayJsonSupportLowPrioImplicits {
 
     def isDefined(node: JsValue) = node != JsNull
     def getScalarValue(node: JsValue) = node match {
-      case JsBoolean(b) ⇒ b
-      case JsNumber(d) ⇒ d.toBigIntExact getOrElse d
-      case JsString(s) ⇒ s
-      case _ ⇒ throw new IllegalStateException(s"$node is not a scalar value")
+      case JsBoolean(b) => b
+      case JsNumber(d) => d.toBigIntExact getOrElse d
+      case JsString(s) => s
+      case _ => throw new IllegalStateException(s"$node is not a scalar value")
     }
 
     def getScalaScalarValue(node: JsValue) = getScalarValue(node)
@@ -69,8 +69,8 @@ object sprayJson extends SprayJsonSupportLowPrioImplicits {
     def isEnumNode(node: JsValue) = node.isInstanceOf[JsString]
 
     def isScalarNode(node: JsValue) = node match {
-      case _: JsBoolean | _: JsNumber | _: JsString ⇒ true
-      case _ ⇒ false
+      case _: JsBoolean | _: JsNumber | _: JsString => true
+      case _ => false
     }
 
     def isVariableNode(node: JsValue) = false
@@ -96,14 +96,14 @@ object sprayJson extends SprayJsonSupportLowPrioImplicits {
 
   implicit def sprayJsonWriterToInput[T : JsonWriter]: ToInput[T, JsValue] =
     new ToInput[T, JsValue] {
-      def toInput(value: T) = implicitly[JsonWriter[T]].write(value) → SprayJsonInputUnmarshaller
+      def toInput(value: T) = implicitly[JsonWriter[T]].write(value) -> SprayJsonInputUnmarshaller
     }
 
   implicit def sprayJsonReaderFromInput[T : JsonReader]: FromInput[T] =
     new FromInput[T] {
       val marshaller = SprayJsonResultMarshaller
       def fromResult(node: marshaller.Node) = try implicitly[JsonReader[T]].read(node) catch {
-        case e: DeserializationException ⇒ throw InputParsingError(Vector(e.msg))
+        case e: DeserializationException => throw InputParsingError(Vector(e.msg))
       }
     }
 

--- a/src/test/scala/sangria/marshalling/SprayJsonSupportSpec.scala
+++ b/src/test/scala/sangria/marshalling/SprayJsonSupportSpec.scala
@@ -35,10 +35,10 @@ class SprayJsonSupportSpec extends WordSpec with Matchers with MarshallingBehavi
   }
 
   val toRender = JsObject(
-    "a" → JsArray(JsNull, JsNumber(123), JsArray(JsObject("foo" → JsString("bar")))),
-    "b" → JsObject(
-      "c" → JsBoolean(true),
-      "d" → JsNull))
+    "a" -> JsArray(JsNull, JsNumber(123), JsArray(JsObject("foo" -> JsString("bar")))),
+    "b" -> JsObject(
+      "c" -> JsBoolean(true),
+      "d" -> JsNull))
 
   "InputUnmarshaller" should {
     "throw an exception on invalid scalar values" in {


### PR DESCRIPTION
In order for sangria to target 2.13, the dependencies must target 2.13.

- 2.12 build was bumped to the latest version
- bumped minor version number
- added cross-build with scala 2.13
- replaced deprecated unicode arrows with plain ones

This was built against marshalling-api 2.0.0-snapshot and marshalling-testkit 1.1.0-snapshot which were published locally from the following PRs:
https://github.com/sangria-graphql/sangria-marshalling-api/pull/4
https://github.com/sangria-graphql/sangria-marshalling-testkit/pull/2