### PR TITLE
Upgrade sangria-marshalling-api version for Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ javacOptions ++= Seq("-source", "8", "-target", "8")
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.8",
-  ("io.spray" %% "spray-json" % "1.3.6").cross(CrossVersion.for3Use2_13),
+  "io.spray" %% "spray-json" % "1.3.6",
   "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.4" % Test,
   "org.scalatest" %% "scalatest" % "3.2.12" % Test
 )


### PR DESCRIPTION
Also set spray-json to use a native Scala 3 version as well.