### PR TITLE
remove for3Use2_13 for spray json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ javacOptions ++= Seq("-source", "8", "-target", "8")
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.8",
-  ("io.spray" %% "spray-json" % "1.3.6").cross(CrossVersion.for3Use2_13),
+  "io.spray" %% "spray-json" % "1.3.6",
   "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.4" % Test,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test
 )


### PR DESCRIPTION
Hi,

SBT build is using 2.13 jar version of spray-json but a version of spray-json for scala 3 seems to have been published.
https://mvnrepository.com/artifact/io.spray/spray-json_3/1.3.6

So, this PR removes the for3Use2_13 configuration to rely on the scala 3 dependency.

Please, let me know if you need further changes or information.

Regards,